### PR TITLE
Fixed necessary constraint being removed

### DIFF
--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -202,9 +202,12 @@
     
     previousView = [self lastVisibleItem];
     nextView = nil;
+    bool previousIsFirst = (self.subviews.count == 1);
     
     NSArray *constraints = [self constraintsBetweenView:self andView:previousView inAxis:self.axis];
     [self removeConstraints:constraints];
+    if (previousIsFirst)
+        [self.distributionStrategy alignView:previousView afterView:nil];
     
     if (newItem) {
       [self addSubview:view];


### PR DESCRIPTION
Had a problem while using aligning views inside of an autoresizable view.
The generated constraints for the OAStackView and it's subviews looked like this:
    [View]-(0)-[View]-(0)-[View]-|

when it should look like:
    |-[View]-(0)-[View]-(0)-[View]-|
