### PR TITLE
[WIP] Fixes issues with the arrangedSubviews property

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -206,6 +206,8 @@
 		E91726963A1D70D65A0C6428 /* KWRespondToSelectorMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CA8AD367C971DD82427F4AE /* KWRespondToSelectorMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		E943786F62DF61D7A6454356 /* KWBeMemberOfClassMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EFCED26B5D9A256C2B1F238 /* KWBeMemberOfClassMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E961F1E03FB1C2349361DD43 /* KWProbe.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ED94E0B9B0394509B3E09C5 /* KWProbe.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E98AFA0C1B3C336D00CDF427 /* OAStackView_ArrangedSubviews.h in Headers */ = {isa = PBXBuildFile; fileRef = E98AFA0B1B3C336D00CDF427 /* OAStackView_ArrangedSubviews.h */; };
+		E98AFA0E1B3C337400CDF427 /* OAStackView_ArrangedSubviews.h in Headers */ = {isa = PBXBuildFile; fileRef = E98AFA0B1B3C336D00CDF427 /* OAStackView_ArrangedSubviews.h */; };
 		EB6342DDFC16EA1697673367 /* NSInvocation+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 87EF738D1C4A43D46DF7218C /* NSInvocation+OCMAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EBA3CB1AFC1C14BE0CE682AD /* KWRegisterMatchersNode.h in Headers */ = {isa = PBXBuildFile; fileRef = ACC8D3E191EA0619F7399012 /* KWRegisterMatchersNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EBD4862464FD997A831166EA /* KWSuiteConfigurationBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 30DA7C8C1EFC416457FC8B42 /* KWSuiteConfigurationBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -498,6 +500,7 @@
 		E91B86F74BD64D5D3108D23A /* Pods-OAStackView_Example-OAStackView-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-OAStackView_Example-OAStackView-umbrella.h"; sourceTree = "<group>"; };
 		E96052DEDBABAD6DE67AB9CC /* KWVerifying.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWVerifying.h; path = Classes/Verifiers/KWVerifying.h; sourceTree = "<group>"; };
 		E9763017ABDD60733231C7B9 /* KWBeforeEachNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeforeEachNode.m; path = Classes/Nodes/KWBeforeEachNode.m; sourceTree = "<group>"; };
+		E98AFA0B1B3C336D00CDF427 /* OAStackView_ArrangedSubviews.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OAStackView_ArrangedSubviews.h; sourceTree = "<group>"; };
 		E9DCF701A29E982F7F76150C /* Pods-OAStackView_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OAStackView_Example.release.xcconfig"; sourceTree = "<group>"; };
 		EC4FD93B76378B54BA02E9D3 /* KWGenericMatchEvaluator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWGenericMatchEvaluator.m; path = Classes/Matchers/KWGenericMatchEvaluator.m; sourceTree = "<group>"; };
 		EE003196DB6E4BE2B7583341 /* Pods-OAStackView_Tests-OAStackView.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OAStackView_Tests-OAStackView.xcconfig"; path = "../Pods-OAStackView_Tests-OAStackView/Pods-OAStackView_Tests-OAStackView.xcconfig"; sourceTree = "<group>"; };
@@ -586,6 +589,7 @@
 			children = (
 				8B90E6BD21591A4585962496 /* OAStackView.h */,
 				5D2F4F1397A17E203EA8112B /* OAStackView.m */,
+				E98AFA0B1B3C336D00CDF427 /* OAStackView_ArrangedSubviews.h */,
 				C809B772AB6D8B7D66C7D8A2 /* OAStackView+Constraint.h */,
 				E822B703CD09D5556B8F8265 /* OAStackView+Constraint.m */,
 				E86334892F73798F2B097D5F /* OAStackView+Hiding.h */,
@@ -1067,6 +1071,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E98AFA0E1B3C337400CDF427 /* OAStackView_ArrangedSubviews.h in Headers */,
 				D69542A762933D4119F4037C /* OAStackView+Constraint.h in Headers */,
 				05794B5F4247E3A648C40B51 /* OAStackView+Hiding.h in Headers */,
 				B1868D729956D7DEC9C9FE06 /* OAStackView+Traversal.h in Headers */,
@@ -1089,6 +1094,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E98AFA0C1B3C336D00CDF427 /* OAStackView_ArrangedSubviews.h in Headers */,
 				06EC4010B3D981437FC3D92B /* OAStackView+Constraint.h in Headers */,
 				19308B2A9CB35F4AD26FD0CF /* OAStackView+Hiding.h in Headers */,
 				46CA8779A92EBC2D28E4C1EC /* OAStackView+Traversal.h in Headers */,

--- a/Pod/Classes/OAStackView+Constraint.m
+++ b/Pod/Classes/OAStackView+Constraint.m
@@ -21,8 +21,7 @@
       viewMatches = viewMatches || (firstView == constraint.secondItem && otherView == constraint.firstItem);
     }
     
-    BOOL isCorrectAxis = [self isConstraintAttribute:constraint.firstAttribute affectingAxis:axis] ||
-    [self isConstraintAttribute:constraint.secondAttribute affectingAxis:axis];
+    BOOL isCorrectAxis = [self isConstraint:constraint affectingAxis:axis];
     
     if (viewMatches && isCorrectAxis) {
       [arr addObject:constraint];
@@ -141,15 +140,29 @@
     case UILayoutConstraintAxisHorizontal:
       return attribute == NSLayoutAttributeLeft || attribute == NSLayoutAttributeRight ||
       attribute == NSLayoutAttributeLeading || attribute == NSLayoutAttributeTrailing ||
-      attribute == NSLayoutAttributeCenterX || attribute == NSLayoutAttributeWidth;
+      attribute == NSLayoutAttributeCenterX || attribute == NSLayoutAttributeWidth
+#if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_7_1
+      || attribute == NSLayoutAttributeLeftMargin || attribute == NSLayoutAttributeRightMargin ||
+      attribute == NSLayoutAttributeLeadingMargin || attribute == NSLayoutAttributeTrailingMargin ||
+      attribute == NSLayoutAttributeCenterXWithinMargins
+#endif
+      ;
       break;
       
     case UILayoutConstraintAxisVertical:
       return attribute == NSLayoutAttributeTop || attribute == NSLayoutAttributeBottom ||
-      attribute == NSLayoutAttributeCenterY || attribute == NSLayoutAttributeHeight;
+      attribute == NSLayoutAttributeCenterY || attribute == NSLayoutAttributeHeight ||
+      attribute == NSLayoutAttributeBaseline
+#if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_7_1
+      || attribute == NSLayoutAttributeLastBaseline || attribute == NSLayoutAttributeFirstBaseline ||
+      attribute == NSLayoutAttributeTopMargin || attribute == NSLayoutAttributeBottomMargin ||
+      attribute == NSLayoutAttributeCenterYWithinMargins
+#endif
+      ;
       break;
       
     default:
+      return NO;
       break;
   }
 }

--- a/Pod/Classes/OAStackView+Hiding.m
+++ b/Pod/Classes/OAStackView+Hiding.m
@@ -51,16 +51,4 @@
   
 }
 
-#pragma mark subviews
-
-- (void)didAddSubview:(UIView *)subview {
-  [super didAddSubview:subview];
-  [self addObserverForView:subview];
-}
-
-- (void)willRemoveSubview:(UIView *)subview {
-  [super willRemoveSubview:subview];
-  [self removeObserverForView:subview];
-}
-
 @end

--- a/Pod/Classes/OAStackView+Traversal.h
+++ b/Pod/Classes/OAStackView+Traversal.h
@@ -10,15 +10,13 @@
 
 @interface OAStackView (Traversal)
 
-- (UIView*)visibleViewBeforeIndex:(NSInteger)index;
-- (UIView*)visibleViewBeforeView:(UIView*)view;
+- (UIView*)arrangedSubviewBeforeIndex:(NSInteger)index;
+- (UIView*)arrangedSubviewBeforeView:(UIView*)view;
 
-- (UIView*)visibleViewAfterIndex:(NSInteger)index;
-- (UIView*)visibleViewAfterView:(UIView*)view;
+- (UIView*)arrangedSubviewAfterIndex:(NSInteger)index;
+- (UIView*)arrangedSubviewAfterView:(UIView*)view;
 
-- (void)iterateVisibleViews:(void (^) (UIView *view, UIView *previousView))block;
-
-- (UIView*)lastVisibleItem;
+- (void)iterateArrangedSubviews:(void (^) (UIView *view, UIView *previousView))block;
 
 - (NSLayoutConstraint*)firstViewConstraint;
 - (NSLayoutConstraint*)lastViewConstraint;

--- a/Pod/Classes/OAStackView+Traversal.m
+++ b/Pod/Classes/OAStackView+Traversal.m
@@ -7,70 +7,48 @@
 //
 
 #import "OAStackView+Traversal.h"
+#import "OAStackView_ArrangedSubviews.h"
 
 @implementation OAStackView (Traversal)
 
-- (UIView*)visibleViewBeforeView:(UIView*)view {
-  NSInteger index = [self.subviews indexOfObject:view];
+- (UIView*)arrangedSubviewBeforeView:(UIView*)view {
+  NSInteger index = [self indexInArrangedSubviewsOfObject:view];
   if (index == NSNotFound) { return nil; }
   
-  return [self visibleViewBeforeIndex:index];
+  return [self arrangedSubviewBeforeIndex:index];
 }
 
-- (UIView*)visibleViewAfterView:(UIView*)view {
-  NSInteger index = [self.subviews indexOfObject:view];
+- (UIView*)arrangedSubviewAfterView:(UIView*)view {
+  NSInteger index = [self indexInArrangedSubviewsOfObject:view];
   if (index == NSNotFound) { return nil; }
   
-  return [self visibleViewAfterIndex:index];
+  return [self arrangedSubviewAfterIndex:index];
 }
 
-- (UIView*)visibleViewAfterIndex:(NSInteger)index {
-  for (NSInteger i = index + 1; i < self.subviews.count; i++) {
-    UIView *theView = self.subviews[i];
-    if (!theView.hidden) {
-      return theView;
-    }
+- (UIView*)arrangedSubviewAfterIndex:(NSInteger)index {
+  if ((index + 1) < [self countOfArrangedSubviews]) {
+    return [self objectInArrangedSubviewsAtIndex:index+1];
   }
   
   return nil;
 }
 
-- (UIView*)visibleViewBeforeIndex:(NSInteger)index {
-  for (NSInteger i = index - 1; i >= 0; i--) {
-    UIView *theView = self.subviews[i];
-    if (!theView.hidden) {
-      return theView;
-    }
+- (UIView*)arrangedSubviewBeforeIndex:(NSInteger)index {
+  if (index > 0) {
+    return [self objectInArrangedSubviewsAtIndex:index-1];
   }
   
   return nil;
 }
 
-- (UIView*)lastVisibleItem {
-  return [self visibleViewBeforeIndex:self.subviews.count];
-}
-
-- (void)iterateVisibleViews:(void (^) (UIView *view, UIView *previousView))block {
-  
-  id previousView;
-  for (UIView *view in self.subviews) {
-    if (view.isHidden) { continue; }
+- (void)iterateArrangedSubviews:(void (^) (UIView *view, UIView *previousView))block {
+  UIView *previousView = nil;
+  for (NSUInteger i = 0; i < [self countOfArrangedSubviews]; i++) {
+    UIView *view = [self objectInArrangedSubviewsAtIndex:i];
     
     block(view, previousView);
     previousView = view;
   }
-}
-
-- (NSArray*)currentVisibleViews {
-  NSMutableArray *arr = [@[] mutableCopy];
-  [self iterateVisibleViews:^(UIView *view, UIView *previousView) {
-    [arr addObject:view];
-  }];
-  return arr;
-}
-
-- (BOOL)isLastVisibleItem:(UIView*)view {
-  return view == [self lastVisibleItem];
 }
 
 - (NSLayoutConstraint*)lastViewConstraint {
@@ -113,7 +91,7 @@
 }
 
 - (BOOL)isViewLastItem:(UIView*)view excludingItem:(UIView*)excludingItem {
-  NSArray *visible = [self currentVisibleViews];
+  NSArray *visible = [self arrangedSubviews];
   NSInteger index = [visible indexOfObject:view];
   NSInteger exclutedIndex = [visible indexOfObject:excludingItem];
   

--- a/Pod/Classes/OAStackView.h
+++ b/Pod/Classes/OAStackView.h
@@ -83,6 +83,8 @@ typedef NS_ENUM(NSInteger, OAStackViewAlignment) {
 NS_ASSUME_NONNULL_BEGIN
 @interface OAStackView : UIView
 
+// The views that are currently being arranged.
+// Views that are hidden will be removed from this list
 @property(nonatomic,readonly,copy) NSArray *arrangedSubviews;
 
 //Default is Vertical

--- a/Pod/Classes/OAStackView.h
+++ b/Pod/Classes/OAStackView.h
@@ -76,8 +76,9 @@ typedef NS_ENUM(NSInteger, OAStackViewAlignment) {
 #define NS_ASSUME_NONNULL_BEGIN
 #define NS_ASSUME_NONNULL_END
 #define nullable
-#define nonnullable
+#define nonnull
 #define __nullable
+#define __nonnull
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -195,8 +195,7 @@
 
 #pragma mark - Adding and removing
 
-- (void)addArrangedSubviews:(NSArray *)views
-{
+- (void)addArrangedSubviews:(NSArray *)views {
   for (UIView *view in views) {
     [self addArrangedSubview:view];
   }
@@ -207,6 +206,7 @@
 }
 
 - (void)insertArrangedSubview:(UIView * __nonnull)view atIndex:(NSUInteger)stackIndex {
+  [self addSubview:view];
   [self insertObject:view inArrangedSubviewsAtIndex:stackIndex];
 }
 

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -168,29 +168,6 @@
 
 - (void)layoutSubviews {
   [super layoutSubviews];
-  [self invalidateIntrinsicContentSize];
-}
-
-- (CGSize)intrinsicContentSize {
-  CGSize size = [super intrinsicContentSize];
-  
-  __block float maxSize = 0;
-  
-  [self iterateArrangedSubviews:^(UIView *view, UIView *previousView) {
-    if (self.axis == UILayoutConstraintAxisVertical) {
-      maxSize = fmaxf(maxSize, CGRectGetWidth(view.frame));
-    } else {
-      maxSize = fmaxf(maxSize, CGRectGetHeight(view.frame));
-    }
-  }];
-  
-  if (self.axis == UILayoutConstraintAxisVertical) {
-    size.width = maxSize;
-  } else {
-    size.height = maxSize;
-  }
-  
-  return size;
 }
 
 #pragma mark - Adding and removing

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -38,6 +38,14 @@
   return self;
 }
 
+- (instancetype)init {
+  self = [self initWithArrangedSubviews:@[]];
+  if (self) {
+  
+  }
+  return self;
+}
+
 - (instancetype)initWithArrangedSubviews:(NSArray*)views {
   self = [super initWithFrame:CGRectZero];
   

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -321,15 +321,15 @@
   return [_mutableArrangedSubviews count];
 }
 
-- (UIView *)objectInArrangedSubviewsAtIndex:(NSUInteger)index {
+- (UIView * __nonnull)objectInArrangedSubviewsAtIndex:(NSUInteger)index {
   return [_mutableArrangedSubviews objectAtIndex:index];
 }
 
-- (NSUInteger)indexInArrangedSubviewsOfObject:(UIView *)view {
+- (NSUInteger)indexInArrangedSubviewsOfObject:(UIView * __nonnull)view {
   return [_mutableArrangedSubviews indexOfObject:view];
 }
 
-- (void)insertObject:(UIView *)object inArrangedSubviewsAtIndex:(NSUInteger)index {
+- (void)insertObject:(UIView * __nonnull)object inArrangedSubviewsAtIndex:(NSUInteger)index {
   [_mutableArrangedSubviews insertObject:object atIndex:index];
   [self didAddArrangedSubview:object];
 }
@@ -344,11 +344,11 @@
   return [_mutableArrangedSubviews copy];
 }
 
-- (UIView *)firstArrangedSubview {
+- (UIView * __nullable)firstArrangedSubview {
   return [_mutableArrangedSubviews firstObject];
 }
 
-- (UIView *)lastArrangedSubview {
+- (UIView * __nullable)lastArrangedSubview {
   return [_mutableArrangedSubviews lastObject];
 }
 

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -183,8 +183,21 @@
 }
 
 - (void)insertArrangedSubview:(UIView * __nonnull)view atIndex:(NSUInteger)stackIndex {
+  NSUInteger previousIndex = [self indexInArrangedSubviewsOfObject:view];
+  NSUInteger newIndex = stackIndex;
+  
+  if (previousIndex == newIndex) { return; }
+  
+  if (previousIndex != NSNotFound) {
+    // view was already arranged, remove first
+    [self removeArrangedSubview:view];
+    if (previousIndex < newIndex) {
+      newIndex--;
+    }
+  }
+
   [self addSubview:view];
-  [self insertObject:view inArrangedSubviewsAtIndex:stackIndex];
+  [self insertObject:view inArrangedSubviewsAtIndex:newIndex];
 }
 
 - (void)removeArrangedSubview:(UIView *)view {

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -305,6 +305,25 @@
   [self removeObserverForView:subview];
 }
 
+- (UIView *)viewForBaselineLayout {
+  UIView *res = nil;
+  if (self.axis == UILayoutConstraintAxisHorizontal) {
+    for (UIView *arrangedView in _mutableArrangedSubviews) {
+      if (!res || CGRectGetHeight(res.frame) < CGRectGetHeight(arrangedView.frame)) {
+        res = arrangedView;
+      }
+    }
+    
+  } else {
+    res = [self lastArrangedSubview];
+  }
+    
+  if ([res isKindOfClass:[self class]]) {
+    res = [res viewForBaselineLayout];
+  }
+  return res;
+}
+
 #pragma mark KVO-compatible Mutable Indexed Accessors for arrangedSubviews
 - (NSUInteger)countOfArrangedSubviews {
   return [_mutableArrangedSubviews count];

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -220,10 +220,6 @@
       
     NSArray *constraints = [self lastConstraintAffectingView:self andView:previousView inAxis:self.axis];
     [self removeConstraints:constraints];
-    
-    if ([self firstArrangedSubview] == previousView) {
-      [self.distributionStrategy alignView:previousView afterView:nil];
-    }
   } else if (stackIndex == 0) {
     // Prepending a new item
     NSArray *constraints = [self firstConstraintAffectingView:self andView:nextView inAxis:self.axis];
@@ -245,14 +241,10 @@
   id previousView = [self arrangedSubviewBeforeView:view];
   id nextView = [self arrangedSubviewAfterView:view];
   
-  NSArray *constraint = [self constraintsAffectingView:view];
-  [self removeConstraints:constraint];
+  NSArray *constraints = [self constraintsAffectingView:view];
+  [self removeConstraints:constraints];
   
-  if (nextView) {
-    [self.distributionStrategy alignView:nextView afterView:previousView];
-  } else if(previousView) {
-    [self.distributionStrategy alignView:nil afterView:previousView];
-  }
+  [self.distributionStrategy alignView:nextView afterView:previousView];
 }
 
 #pragma mark - Hide and Unhide

--- a/Pod/Classes/OAStackViewAlignmentStrategy.m
+++ b/Pod/Classes/OAStackViewAlignmentStrategy.m
@@ -113,7 +113,7 @@
 
 - (NSArray*)constraintsalignViewOnOtherAxis:(UIView*)view {
   
-  id constraintString = [NSString stringWithFormat:@"%@:|-0-[view]", [self otherAxisString]];
+  id constraintString = [NSString stringWithFormat:@"%@:|-0-[view]-(>=0)-|", [self otherAxisString]];
   
   return [NSLayoutConstraint constraintsWithVisualFormat:constraintString
                                                  options:0
@@ -127,7 +127,7 @@
 
 - (NSArray*)constraintsalignViewOnOtherAxis:(UIView*)view {
   
-  id constraintString = [NSString stringWithFormat:@"%@:[view]-0-|", [self otherAxisString]];
+  id constraintString = [NSString stringWithFormat:@"%@:|-(>=0)-[view]-0-|", [self otherAxisString]];
   
   return [NSLayoutConstraint constraintsWithVisualFormat:constraintString
                                                  options:0
@@ -141,12 +141,22 @@
 
 - (NSArray*)constraintsalignViewOnOtherAxis:(UIView*)view {
   
-  return @[[NSLayoutConstraint constraintWithItem:view
-                               attribute:[self centerAttribute]
-                               relatedBy:NSLayoutRelationEqual
-                                  toItem:view.superview
-                               attribute:[self centerAttribute]
-                                       multiplier:1 constant:0]];
+  NSString *constraintString = [NSString stringWithFormat:@"%@:|-(>=0)-[view]-(>=0)-|", [self otherAxisString]];
+  
+  NSArray *edgeConstraints = [NSLayoutConstraint constraintsWithVisualFormat:constraintString
+                                                 options:0
+                                                 metrics:nil
+                                                   views:NSDictionaryOfVariableBindings(view)];
+  
+  NSLayoutConstraint *centerContraint = [NSLayoutConstraint constraintWithItem:view
+                                                                     attribute:[self centerAttribute]
+                                                                     relatedBy:NSLayoutRelationEqual
+                                                                        toItem:view.superview
+                                                                     attribute:[self centerAttribute]
+                                                                    multiplier:1
+                                                                      constant:0];
+    
+  return [edgeConstraints arrayByAddingObject:centerContraint];
 }
 
 @end

--- a/Pod/Classes/OAStackView_ArrangedSubviews.h
+++ b/Pod/Classes/OAStackView_ArrangedSubviews.h
@@ -1,0 +1,27 @@
+//
+//  OAStackView_ArrangedSubviews.h
+//  Pods
+//
+//  Created by Thomas Visser on 25/06/15.
+//
+//
+
+#import <OAStackView/OAStackView.h>
+
+@interface OAStackView ()
+
+- (NSUInteger)countOfArrangedSubviews;
+
+- (nonnull UIView*)objectInArrangedSubviewsAtIndex:(NSUInteger)index;
+
+- (NSUInteger)indexInArrangedSubviewsOfObject:(nonnull UIView *)view;
+
+- (void)insertObject:(nullable UIView *)object inArrangedSubviewsAtIndex:(NSUInteger)index;
+
+- (void)removeObjectFromArrangedSubviewsAtIndex:(NSUInteger)index;
+
+- (nullable UIView *)firstArrangedSubview;
+
+- (nullable UIView *)lastArrangedSubview;
+
+@end

--- a/Pod/Classes/OAStackView_ArrangedSubviews.h
+++ b/Pod/Classes/OAStackView_ArrangedSubviews.h
@@ -12,16 +12,16 @@
 
 - (NSUInteger)countOfArrangedSubviews;
 
-- (nonnull UIView*)objectInArrangedSubviewsAtIndex:(NSUInteger)index;
+- (UIView* __nonnull)objectInArrangedSubviewsAtIndex:(NSUInteger)index;
 
-- (NSUInteger)indexInArrangedSubviewsOfObject:(nonnull UIView *)view;
+- (NSUInteger)indexInArrangedSubviewsOfObject:(UIView * __nonnull)view;
 
-- (void)insertObject:(nullable UIView *)object inArrangedSubviewsAtIndex:(NSUInteger)index;
+- (void)insertObject:(UIView * __nonnull)object inArrangedSubviewsAtIndex:(NSUInteger)index;
 
 - (void)removeObjectFromArrangedSubviewsAtIndex:(NSUInteger)index;
 
-- (nullable UIView *)firstArrangedSubview;
+- (UIView * __nullable)firstArrangedSubview;
 
-- (nullable UIView *)lastArrangedSubview;
+- (UIView * __nullable)lastArrangedSubview;
 
 @end


### PR DESCRIPTION
This is quite a big PR, so please bear with me and let me know if you are open for changes like this.

I found that the `arrangedSubviews` property was not properly implemented. For starters, it was always `nil`. Looking for a solution, I found that the heavy reliance on `self.subviews` made it impossible to implement arranged subviews. I started shuffling things around and here we are...

Main improvements:
- arrangedSubviews is now non-nil and should be kvo'able
- removing an arranged view now does not remove the view as a subview
- it should now be possible to have subviews in the OAStackView that are not managed by the stack view

All the tests pass and the example project runs fine, but I'd like to do some more testing in my own project. Let me know what you think!
