### PR TITLE
Adds equal centering implementation

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -69,6 +69,9 @@
 		46CA8779A92EBC2D28E4C1EC /* OAStackView+Traversal.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B132E002F0EAE6F7C4C007 /* OAStackView+Traversal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		493526E82666FF2E67312D04 /* KWBeSubclassOfClassMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = A0352A63AB9BF027C69D98B2 /* KWBeSubclassOfClassMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		4980BB2E4FBE7EA2EED0FF92 /* KWNilMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E77CA3AFAADCEC9394516EF /* KWNilMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		4B0F8F231B44C36F0036F739 /* _OALayoutGuide.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B0F8F211B44C36F0036F739 /* _OALayoutGuide.h */; };
+		4B0F8F251B44C37B0036F739 /* _OALayoutGuide.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F8F221B44C36F0036F739 /* _OALayoutGuide.m */; };
+		4B0F8F261B44C3850036F739 /* _OALayoutGuide.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F8F221B44C36F0036F739 /* _OALayoutGuide.m */; };
 		4D581923EEB3544ED549CB5B /* KWPendingNode.m in Sources */ = {isa = PBXBuildFile; fileRef = A52C7E63345A9BCDFEE5B3F6 /* KWPendingNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		4DEE1BB8F64C4763D6585683 /* OAStackView.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 667360543B85E1CE0E6BD756 /* OAStackView.bundle */; };
 		4DFB3EBCDB8022C0B5768FD4 /* KWExistVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 8ED9899540CA916F53DBEC34 /* KWExistVerifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -331,6 +334,8 @@
 		482F8D64D26B3EC3C01F0736 /* KWEqualMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWEqualMatcher.h; path = Classes/Matchers/KWEqualMatcher.h; sourceTree = "<group>"; };
 		48AB2EEA34B551ADEBA08821 /* KWReporting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWReporting.h; path = Classes/Core/KWReporting.h; sourceTree = "<group>"; };
 		497268F3953469FEF7923067 /* KWReceiveMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWReceiveMatcher.h; path = Classes/Matchers/KWReceiveMatcher.h; sourceTree = "<group>"; };
+		4B0F8F211B44C36F0036F739 /* _OALayoutGuide.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _OALayoutGuide.h; sourceTree = "<group>"; };
+		4B0F8F221B44C36F0036F739 /* _OALayoutGuide.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _OALayoutGuide.m; sourceTree = "<group>"; };
 		4DEBCBE61FFB94A608259909 /* Pods-OAStackView_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-OAStackView_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		5037740C0F7A842E1BED6BA7 /* Pods-OAStackView_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-OAStackView_Example.modulemap"; sourceTree = "<group>"; };
 		5250EF14BDA1D35A1871BA93 /* NSObject+KiwiMockAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+KiwiMockAdditions.h"; path = "Classes/Mocking/NSObject+KiwiMockAdditions.h"; sourceTree = "<group>"; };
@@ -596,6 +601,8 @@
 				024194B58731070E9AC9710B /* OAStackViewAlignmentStrategy.m */,
 				63CD8F567707C8CFAFF87734 /* OAStackViewDistributionStrategy.h */,
 				C23A1311AA2C1EA1D567AE58 /* OAStackViewDistributionStrategy.m */,
+				4B0F8F211B44C36F0036F739 /* _OALayoutGuide.h */,
+				4B0F8F221B44C36F0036F739 /* _OALayoutGuide.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1082,6 +1089,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0092151033DD1E9F907BAF60 /* Pods-OAStackView_Example-umbrella.h in Headers */,
+				4B0F8F231B44C36F0036F739 /* _OALayoutGuide.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1311,6 +1319,7 @@
 				7CCD749F07E4C3F9C9E0C687 /* OAStackView.m in Sources */,
 				B3DA5C9CA52D5353ECF76E3A /* OAStackViewAlignmentStrategy.m in Sources */,
 				26DB8BFE41E064ECDB11D8C8 /* OAStackViewDistributionStrategy.m in Sources */,
+				4B0F8F251B44C37B0036F739 /* _OALayoutGuide.m in Sources */,
 				2D244FB15A71F1EEB4C6B2F9 /* Pods-OAStackView_Tests-OAStackView-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1438,6 +1447,7 @@
 				235C8C9E0E1BC9B6C63772E7 /* OAStackView.m in Sources */,
 				4F9890B79209225AF6EB2BE0 /* OAStackViewAlignmentStrategy.m in Sources */,
 				C621CDC255C81BF4E4586068 /* OAStackViewDistributionStrategy.m in Sources */,
+				4B0F8F261B44C3850036F739 /* _OALayoutGuide.m in Sources */,
 				9B09054C59C1091972A13435 /* Pods-OAStackView_Example-OAStackView-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -69,9 +69,10 @@
 		46CA8779A92EBC2D28E4C1EC /* OAStackView+Traversal.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B132E002F0EAE6F7C4C007 /* OAStackView+Traversal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		493526E82666FF2E67312D04 /* KWBeSubclassOfClassMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = A0352A63AB9BF027C69D98B2 /* KWBeSubclassOfClassMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		4980BB2E4FBE7EA2EED0FF92 /* KWNilMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E77CA3AFAADCEC9394516EF /* KWNilMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		4B0F8F231B44C36F0036F739 /* _OALayoutGuide.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B0F8F211B44C36F0036F739 /* _OALayoutGuide.h */; };
 		4B0F8F251B44C37B0036F739 /* _OALayoutGuide.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F8F221B44C36F0036F739 /* _OALayoutGuide.m */; };
 		4B0F8F261B44C3850036F739 /* _OALayoutGuide.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F8F221B44C36F0036F739 /* _OALayoutGuide.m */; };
+		4B2AD8901B46F04900285D06 /* _OALayoutGuide.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B0F8F211B44C36F0036F739 /* _OALayoutGuide.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4B2AD8911B46F05300285D06 /* _OALayoutGuide.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B0F8F211B44C36F0036F739 /* _OALayoutGuide.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4D581923EEB3544ED549CB5B /* KWPendingNode.m in Sources */ = {isa = PBXBuildFile; fileRef = A52C7E63345A9BCDFEE5B3F6 /* KWPendingNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		4DEE1BB8F64C4763D6585683 /* OAStackView.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 667360543B85E1CE0E6BD756 /* OAStackView.bundle */; };
 		4DFB3EBCDB8022C0B5768FD4 /* KWExistVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 8ED9899540CA916F53DBEC34 /* KWExistVerifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1075,6 +1076,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D69542A762933D4119F4037C /* OAStackView+Constraint.h in Headers */,
+				4B2AD8911B46F05300285D06 /* _OALayoutGuide.h in Headers */,
 				05794B5F4247E3A648C40B51 /* OAStackView+Hiding.h in Headers */,
 				B1868D729956D7DEC9C9FE06 /* OAStackView+Traversal.h in Headers */,
 				37B2C7C8BF93DB6160C1D1A9 /* OAStackView.h in Headers */,
@@ -1089,7 +1091,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				0092151033DD1E9F907BAF60 /* Pods-OAStackView_Example-umbrella.h in Headers */,
-				4B0F8F231B44C36F0036F739 /* _OALayoutGuide.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1098,6 +1099,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				06EC4010B3D981437FC3D92B /* OAStackView+Constraint.h in Headers */,
+				4B2AD8901B46F04900285D06 /* _OALayoutGuide.h in Headers */,
 				19308B2A9CB35F4AD26FD0CF /* OAStackView+Hiding.h in Headers */,
 				46CA8779A92EBC2D28E4C1EC /* OAStackView+Traversal.h in Headers */,
 				CE2D928275880C806D33DE2D /* OAStackView.h in Headers */,

--- a/Example/Tests/OAStackViewSpec.m
+++ b/Example/Tests/OAStackViewSpec.m
@@ -468,6 +468,27 @@ describe(@"OAStackView", ^{
           [[theValue(CGRectGetHeight(view3.frame)) should] beWithin:theValue(1) of:theValue(CGRectGetHeight(view2.frame) * proportion)];
         });
       });
+
+      context(@"OAStackViewDistributionEqualSpacing", ^{
+        it(@"Distributes the views with equal spacing between each view", ^{
+          // Views 1, 2 and 3 are UIButtons. Changing the title affects their intrinsicContentSize.
+
+          [(UIButton *)view1 setTitle:@"A short title" forState:UIControlStateNormal];
+          [(UIButton *)view2 setTitle:@"A bit longer title" forState:UIControlStateNormal];
+          [(UIButton *)view3 setTitle:@"A really really really really long title"
+                             forState:UIControlStateNormal];
+
+          stackView.distribution = OAStackViewDistributionEqualSpacing;
+          stackView.spacing = 40;
+
+          layoutView(stackView);
+
+          CGFloat firstGap = CGRectGetMinY(view2.frame) - CGRectGetMaxY(view1.frame);
+          CGFloat secondGap = CGRectGetMinY(view3.frame) - CGRectGetMaxY(view2.frame);
+          [[theValue(firstGap) should] equal:theValue(secondGap)];
+          [[theValue(firstGap) should] beBetween:theValue(stackView.spacing) and:theValue(CGRectGetHeight(stackView.bounds))];
+        });
+      });
     });
     
   });
@@ -816,94 +837,114 @@ describe(@"OAStackView", ^{
         [[theValue(CGRectGetWidth(stackView.frame)) should] equal:theValue(90)];
         
       });
-      
-      
-      context(@"Distribution", ^{
-        
-        __block UIView *view1, *view2, *view3;
-        
-        beforeEach(^{
-          view1 = createViewP(50, 300, 200, 300);
-          view2 = createViewP(60, 300, 500, 300);
-          view3 = createViewP(100, 300, 600, 330);
-          
-          NSArray *views = @[view1, view2, view3];
-          
-          stackView = [[OAStackView alloc] initWithArrangedSubviews:views];
-          stackView.axis = UILayoutConstraintAxisHorizontal;
-          stackView.translatesAutoresizingMaskIntoConstraints = NO;
-        });
-        
-        context(@"OAStackViewDistributionFill", ^{
-          
-          it(@"Distributes the view based on their fill using OAStackViewDistributionFill", ^{
-            stackView.distribution = OAStackViewDistributionFill;
-            addWidthToView(stackView, 400, 1000);
-            layoutView(stackView);
-            
-            [[theValue(CGRectGetMinX(view1.frame)) should] equal:theValue(0)];
-            
-            [[theValue(CGRectGetMinX(view2.frame)) should] equal:theValue(240)];
-            
-            [[theValue(CGRectGetMinX(view3.frame)) should] equal:theValue(300)];
-          });
-          
-        });
-        
-        context(@"OAStackViewDistributionFillEqually", ^{
-          
-          it(@"Distributes the views equally using OAStackViewDistributionFillEqually", ^{
-            stackView.distribution = OAStackViewDistributionFillEqually;
-            addWidthToView(stackView, 400, 1000);
-            layoutView(stackView);
-            
-            [[theValue(CGRectGetMinX(view1.frame)) should] equal:theValue(0)];
-            
-            [[theValue(CGRectGetMinX(view2.frame)) should] equal:133 withDelta:1];
-            
-            [[theValue(CGRectGetMinX(view3.frame)) should] equal:266 withDelta:1];
-          });
-          
-          it(@"Adds the correct spacing between views", ^{
-            stackView.distribution = OAStackViewDistributionFillEqually;
-            stackView.spacing = 50;
-            addWidthToView(stackView, 400, 1000);
-            layoutView(stackView);
-            
-            [[theValue(CGRectGetMinX(view1.frame)) should] equal:theValue(0)];
-            
-            [[theValue(CGRectGetMinX(view2.frame)) should] equal:theValue(150)];
-            
-            [[theValue(CGRectGetMinX(view3.frame)) should] equal:theValue(300)];
-          });
-          
-        });
-        
-        context(@"OAStackViewDistributionFillProportionally", ^{
-          it(@"Distributes the views proportionally based on their intrinsicContentSize", ^{
-            // Views 1, 2 and 3 are UIButtons. Changing the title affects their intrinsicContentSize.
-            
-            [(UIButton *)view1 setTitle:@"the title" forState:UIControlStateNormal];
-            [(UIButton *)view2 setTitle:@"the title" forState:UIControlStateNormal];
-            [(UIButton *)view3 setTitle:@"the title the title" forState:UIControlStateNormal];
-            
-            stackView.distribution = OAStackViewDistributionFillProportionally;
-            
-            layoutView(stackView);
-            CGFloat proportion = view2.intrinsicContentSize.width / view1.intrinsicContentSize.width;
-            [[theValue(CGRectGetWidth(view2.frame)) should] beWithin:theValue(1) of:theValue(CGRectGetWidth(view1.frame) * proportion)];
-            
-            proportion = view3.intrinsicContentSize.width / view2.intrinsicContentSize.width;
-            [[theValue(CGRectGetWidth(view3.frame)) should] beWithin:theValue(1) of:theValue(CGRectGetWidth(view2.frame) * proportion)];
-          });
-        });
-        
-        
-      });
-      
-      
+
     });
-    
+      
+      
+    context(@"Distribution", ^{
+
+      __block UIView *view1, *view2, *view3;
+
+      beforeEach(^{
+        view1 = createViewP(50, 300, 200, 300);
+        view2 = createViewP(60, 300, 500, 300);
+        view3 = createViewP(100, 300, 600, 330);
+
+        NSArray *views = @[view1, view2, view3];
+
+        stackView = [[OAStackView alloc] initWithArrangedSubviews:views];
+        stackView.axis = UILayoutConstraintAxisHorizontal;
+        stackView.translatesAutoresizingMaskIntoConstraints = NO;
+      });
+
+      context(@"OAStackViewDistributionFill", ^{
+
+        it(@"Distributes the view based on their fill using OAStackViewDistributionFill", ^{
+          stackView.distribution = OAStackViewDistributionFill;
+          addWidthToView(stackView, 400, 1000);
+          layoutView(stackView);
+
+          [[theValue(CGRectGetMinX(view1.frame)) should] equal:theValue(0)];
+
+          [[theValue(CGRectGetMinX(view2.frame)) should] equal:theValue(240)];
+
+          [[theValue(CGRectGetMinX(view3.frame)) should] equal:theValue(300)];
+        });
+
+      });
+
+      context(@"OAStackViewDistributionFillEqually", ^{
+
+        it(@"Distributes the views equally using OAStackViewDistributionFillEqually", ^{
+          stackView.distribution = OAStackViewDistributionFillEqually;
+          addWidthToView(stackView, 400, 1000);
+          layoutView(stackView);
+
+          [[theValue(CGRectGetMinX(view1.frame)) should] equal:theValue(0)];
+
+          [[theValue(CGRectGetMinX(view2.frame)) should] equal:133 withDelta:1];
+
+          [[theValue(CGRectGetMinX(view3.frame)) should] equal:266 withDelta:1];
+        });
+
+        it(@"Adds the correct spacing between views", ^{
+          stackView.distribution = OAStackViewDistributionFillEqually;
+          stackView.spacing = 50;
+          addWidthToView(stackView, 400, 1000);
+          layoutView(stackView);
+
+          [[theValue(CGRectGetMinX(view1.frame)) should] equal:theValue(0)];
+
+          [[theValue(CGRectGetMinX(view2.frame)) should] equal:theValue(150)];
+
+          [[theValue(CGRectGetMinX(view3.frame)) should] equal:theValue(300)];
+        });
+
+      });
+
+      context(@"OAStackViewDistributionFillProportionally", ^{
+        it(@"Distributes the views proportionally based on their intrinsicContentSize", ^{
+          // Views 1, 2 and 3 are UIButtons. Changing the title affects their intrinsicContentSize.
+
+          [(UIButton *)view1 setTitle:@"the title" forState:UIControlStateNormal];
+          [(UIButton *)view2 setTitle:@"the title" forState:UIControlStateNormal];
+          [(UIButton *)view3 setTitle:@"the title the title" forState:UIControlStateNormal];
+
+          stackView.distribution = OAStackViewDistributionFillProportionally;
+
+          layoutView(stackView);
+          CGFloat proportion = view2.intrinsicContentSize.width / view1.intrinsicContentSize.width;
+          [[theValue(CGRectGetWidth(view2.frame)) should] beWithin:theValue(1) of:theValue(CGRectGetWidth(view1.frame) * proportion)];
+
+          proportion = view3.intrinsicContentSize.width / view2.intrinsicContentSize.width;
+          [[theValue(CGRectGetWidth(view3.frame)) should] beWithin:theValue(1) of:theValue(CGRectGetWidth(view2.frame) * proportion)];
+        });
+      });
+
+      context(@"OAStackViewDistributionEqualSpacing", ^{
+        it(@"Distributes the views with equal spacing between each view", ^{
+          // Views 1, 2 and 3 are UIButtons. Changing the title affects their intrinsicContentSize.
+
+          [(UIButton *)view1 setTitle:@"A short title" forState:UIControlStateNormal];
+          [(UIButton *)view2 setTitle:@"A bit longer title" forState:UIControlStateNormal];
+          [(UIButton *)view3 setTitle:@"A really really really really long title"
+                             forState:UIControlStateNormal];
+
+          stackView.distribution = OAStackViewDistributionEqualSpacing;
+          stackView.spacing = 40;
+
+          layoutView(stackView);
+
+          CGFloat firstGap = CGRectGetMinX(view2.frame) - CGRectGetMaxX(view1.frame);
+          CGFloat secondGap = CGRectGetMinX(view3.frame) - CGRectGetMaxX(view2.frame);
+          [[theValue(firstGap) should] equal:theValue(secondGap)];
+          [[theValue(firstGap) should] beBetween:theValue(stackView.spacing)
+                                             and:theValue(CGRectGetWidth(stackView.bounds))];
+        });
+      });
+
+    });
+
   });
   
   

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -71,7 +71,12 @@
 }
 
 -(void)setOpaque:(BOOL)opaque {
-    // Does not have any effect because `CATransformLayer` is not rendered.
+  // Does not have any effect because `CATransformLayer` is not rendered.
+}
+
+- (void)setClipsToBounds:(BOOL)clipsToBounds
+{
+  // Does not have any effect because `CATransformLayer` is not rendered.
 }
 
 - (void)setSpacing:(CGFloat)spacing {

--- a/Pod/Classes/_OALayoutGuide.h
+++ b/Pod/Classes/_OALayoutGuide.h
@@ -1,0 +1,10 @@
+//
+//  _OALayoutGuide.h
+//  Pods
+//
+
+#import <UIKit/UIKit.h>
+
+@interface _OALayoutGuide : UIView
+
+@end

--- a/Pod/Classes/_OALayoutGuide.m
+++ b/Pod/Classes/_OALayoutGuide.m
@@ -1,0 +1,73 @@
+//
+//  _OALayoutGuide.m
+//  Pods
+//
+
+#import "_OALayoutGuide.h"
+
+@interface _OALayoutGuide ()
+
+@property (nonatomic) BOOL propertiesAreLocked;
+
+@end
+
+@implementation _OALayoutGuide
+
++ (Class)layerClass
+{
+  return [CATransformLayer class];
+}
+
++ (BOOL)requiresConstraintBasedLayout
+{
+  return YES;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+  self  = [super initWithCoder:aDecoder];
+  if (!self) { return nil; }
+
+  [self commonInit];
+
+  return self;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  self  = [super initWithFrame:frame];
+  if (!self) { return nil; }
+
+  [self commonInit];
+
+  return self;
+}
+
+- (void)commonInit
+{
+  self.translatesAutoresizingMaskIntoConstraints = NO;
+  self.userInteractionEnabled = NO;
+  self.hidden = YES;
+
+  self.propertiesAreLocked = YES;
+}
+
+- (void)setHidden:(BOOL)hidden
+{
+  NSAssert(!self.propertiesAreLocked, @"Properties are no longer mutable");
+  [super setHidden:hidden];
+}
+
+- (void)setUserInteractionEnabled:(BOOL)userInteractionEnabled
+{
+  NSAssert(!self.propertiesAreLocked, @"Properties are no longer mutable");
+  [super setUserInteractionEnabled:userInteractionEnabled];
+}
+
+- (void)setBackgroundColor:(UIColor *)backgroundColor {}
+
+- (void)setOpaque:(BOOL)opaque {}
+
+- (void)setClipsToBounds:(BOOL)clipsToBounds {}
+
+@end


### PR DESCRIPTION
Initial pass at an equal spacing distribution implementation. Adds a non-rendering `UIView` subclass to use as layout guides, as suggested in [#13](https://github.com/oarrabi/OAStackView/issues/16). Also made an indentation change to the test spec, which I assumed was an unintended oversight.
