### PR TITLE
Remove unneeded intrinsic content size related code.

### DIFF
--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -165,35 +165,6 @@
     [self layoutArrangedViews];
 }
 
-#pragma mark Layouting
-
-- (void)layoutSubviews {
-  [super layoutSubviews];
-  [self invalidateIntrinsicContentSize];
-}
-
-- (CGSize)intrinsicContentSize {
-  CGSize size = [super intrinsicContentSize];
-  
-  __block float maxSize = 0;
-  
-  [self iterateVisibleViews:^(UIView *view, UIView *previousView) {
-    if (self.axis == UILayoutConstraintAxisVertical) {
-      maxSize = fmaxf(maxSize, CGRectGetWidth(view.frame));
-    } else {
-      maxSize = fmaxf(maxSize, CGRectGetHeight(view.frame));
-    }
-  }];
-  
-  if (self.axis == UILayoutConstraintAxisVertical) {
-    size.width = maxSize;
-  } else {
-    size.height = maxSize;
-  }
-  
-  return size;
-}
-
 #pragma mark - Adding and removing
 
 - (void)addArrangedSubview:(UIView *)view {


### PR DESCRIPTION
## what

It was causing an infinite loop in our App that uses complex layouts with stackViews inside StackViews. We can trigger this easily by setting the dynamic Type text size to anything other than the default text size. Using the default text size does not trigger this problem. Unfortunately I could not get a simple test case to reproduce this behaviour.
## why

This was probably due to calling `invalidateIntrinsicContentSize` from `layoutSubviews`. It's not unreasonable to think that doing so triggers another layout pass causing an infinite loop.
## fix

Removing the `layoutSubviews` override solved the problem. But then again, we don't need to override the `intrinsicContentSize` either. This should only be done on "leaf" custom views that need to provide a size they intrinsically have. StackViews are containers and they don't have an intrinsic content size. Their size depends on the sizes of the views they hold and the constraints it setups between those views. We tested our complex layout and it behaved as we were expecting. These two layouting overrides can be safely removed.
