### PR TITLE
Maintain arranged subviews array

### DIFF
--- a/Example/Tests/OAStackViewSpec.m
+++ b/Example/Tests/OAStackViewSpec.m
@@ -939,6 +939,58 @@ describe(@"OAStackView", ^{
   });
 
 
+  context(@"Arranged Subviews", ^{
+
+    __block UIView *view1, *view2, *view3;
+
+    beforeEach(^{
+      view1 = createView(100, 100);
+      view2 = createView(100, 100);
+      view3 = createView(100, 100);
+
+      stackView = [[OAStackView alloc] init];
+      stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    });
+
+    it(@"Initializes arrangedSubviews to an empty array", ^{
+      [[stackView.arrangedSubviews should] beEmpty];
+    });
+
+    it(@"Initalizes arrangedSubviews to the given views when initialized with arranged subviess", ^{
+      stackView = [[OAStackView alloc] initWithArrangedSubviews:@[view1, view2, view3]];
+      [[stackView.arrangedSubviews should] containObjectsInArray:@[view1, view2, view3]];
+    });
+
+    it(@"Maintains the correct array when adding views", ^{
+      [stackView addArrangedSubview:view1];
+      [[stackView.arrangedSubviews should] containObjectsInArray:@[view1]];
+
+      [stackView addArrangedSubview:view2];
+      [[stackView.arrangedSubviews should] containObjectsInArray:@[view2]];
+
+      [stackView addArrangedSubview:view3];
+      [[stackView.arrangedSubviews should] containObjectsInArray:@[view3]];
+    });
+
+    it(@"Maintains the correct array when removing views", ^{
+      [stackView addArrangedSubview:view1];
+      [stackView addArrangedSubview:view2];
+      [stackView addArrangedSubview:view3];
+
+      [[stackView.arrangedSubviews should] containObjectsInArray:@[view1, view2, view3]];
+
+      [stackView removeArrangedSubview:view2];
+      [[stackView.arrangedSubviews should] containObjectsInArray:@[view1, view3]];
+
+      [stackView removeArrangedSubview:view1];
+      [[stackView.arrangedSubviews should] containObjectsInArray:@[view3]];
+
+      [stackView removeArrangedSubview:view3];
+      [[stackView.arrangedSubviews should] containObjectsInArray:@[]];
+    });
+  });
+
+
   context(@"bug fixes", ^{
   
     __block UIView *view1, *view2, *view3;

--- a/Pod/Classes/OAStackView.h
+++ b/Pod/Classes/OAStackView.h
@@ -84,7 +84,7 @@ typedef NS_ENUM(NSInteger, OAStackViewAlignment) {
 NS_ASSUME_NONNULL_BEGIN
 @interface OAStackView : UIView
 
-@property(nonatomic,readonly,copy) NSArray *arrangedSubviews;
+@property(nonatomic,readonly,copy) NSMutableArray *arrangedSubviews;
 
 //Default is Vertical
 @property(nonatomic) UILayoutConstraintAxis axis;

--- a/Pod/Classes/OAStackView.h
+++ b/Pod/Classes/OAStackView.h
@@ -84,7 +84,7 @@ typedef NS_ENUM(NSInteger, OAStackViewAlignment) {
 NS_ASSUME_NONNULL_BEGIN
 @interface OAStackView : UIView
 
-@property(nonatomic,readonly,copy) NSMutableArray *arrangedSubviews;
+@property(nonatomic,readonly,copy) NSArray *arrangedSubviews;
 
 //Default is Vertical
 @property(nonatomic) UILayoutConstraintAxis axis;

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -15,7 +15,7 @@
 #import "OATransformLayer.h"
 
 @interface OAStackView ()
-@property(nonatomic, copy) NSArray *arrangedSubviews;
+@property(nonatomic, copy) NSMutableArray *arrangedSubviews;
 
 @property(nonatomic) OAStackViewAlignmentStrategy *alignmentStrategy;
 @property(nonatomic) OAStackViewDistributionStrategy *distributionStrategy;
@@ -33,18 +33,17 @@
   self = [super initWithCoder:coder];
   
   if (self) {
-    [self commonInit];
+    [self commonInitWithInitalSubviews:@[]];
   }
   
   return self;
 }
 
-- (instancetype)initWithArrangedSubviews:(NSArray*)views {
+- (instancetype)initWithArrangedSubviews:(NSArray *)views {
   self = [super initWithFrame:CGRectZero];
   
   if (self) {
-    [self addViewsAsSubviews:views];
-    [self commonInit];
+    [self commonInitWithInitalSubviews:views];
   }
   
   return self;
@@ -54,7 +53,10 @@
     return [self initWithArrangedSubviews:@[]];
 }
 
-- (void)commonInit {
+- (void)commonInitWithInitalSubviews:(NSArray *)initialSubviews {
+  _arrangedSubviews = [initialSubviews mutableCopy];
+  [self addViewsAsSubviews:initialSubviews];
+
   _axis = UILayoutConstraintAxisVertical;
   _alignment = OAStackViewAlignmentFill;
   _distribution = OAStackViewDistributionFill;

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -184,6 +184,7 @@
 - (void)removeArrangedSubview:(UIView *)view {
   
   if (self.subviews.count == 1) {
+    [self.arrangedSubviews removeObject:view];
     [view removeFromSuperview];
     return;
   }
@@ -213,6 +214,7 @@
     }
     
     if (newItem) {
+      [self.arrangedSubviews addObject:view];
       [self addSubview:view];
     }
     
@@ -240,6 +242,7 @@
     [self removeConstraints:constraints];
     
     if (newItem) {
+      [self.arrangedSubviews insertObject:view atIndex:stackIndex];
       [self insertSubview:view atIndex:stackIndex];
     }
   }
@@ -259,6 +262,7 @@
   id nextView = [self visibleViewAfterView:view];
   
   if (permanently) {
+    [self.arrangedSubviews removeObject:view];
     [view removeFromSuperview];
   } else {
     NSArray *constraint = [self constraintsAffectingView:view];

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -15,7 +15,8 @@
 #import "OATransformLayer.h"
 
 @interface OAStackView ()
-@property(nonatomic, copy) NSMutableArray *arrangedSubviews;
+@property(nonatomic, copy) NSArray *arrangedSubviews;
+@property(nonatomic, copy) NSMutableArray *mutableArrangedSubviews;
 
 @property(nonatomic) OAStackViewAlignmentStrategy *alignmentStrategy;
 @property(nonatomic) OAStackViewDistributionStrategy *distributionStrategy;
@@ -54,7 +55,7 @@
 }
 
 - (void)commonInitWithInitalSubviews:(NSArray *)initialSubviews {
-  _arrangedSubviews = [initialSubviews mutableCopy];
+  _mutableArrangedSubviews = [initialSubviews mutableCopy];
   [self addViewsAsSubviews:initialSubviews];
 
   _axis = UILayoutConstraintAxisVertical;
@@ -71,6 +72,10 @@
 }
 
 #pragma mark - Properties
+
+- (NSArray *)arrangedSubviews {
+  return self.mutableArrangedSubviews.copy;
+}
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor {
     // Does not have any effect because `CATransformLayer` is not rendered.
@@ -184,7 +189,7 @@
 - (void)removeArrangedSubview:(UIView *)view {
   
   if (self.subviews.count == 1) {
-    [self.arrangedSubviews removeObject:view];
+    [self.mutableArrangedSubviews removeObject:view];
     [view removeFromSuperview];
     return;
   }
@@ -214,7 +219,7 @@
     }
     
     if (newItem) {
-      [self.arrangedSubviews addObject:view];
+      [self.mutableArrangedSubviews addObject:view];
       [self addSubview:view];
     }
     
@@ -242,7 +247,7 @@
     [self removeConstraints:constraints];
     
     if (newItem) {
-      [self.arrangedSubviews insertObject:view atIndex:stackIndex];
+      [self.mutableArrangedSubviews insertObject:view atIndex:stackIndex];
       [self insertSubview:view atIndex:stackIndex];
     }
   }
@@ -262,7 +267,7 @@
   id nextView = [self visibleViewAfterView:view];
   
   if (permanently) {
-    [self.arrangedSubviews removeObject:view];
+    [self.mutableArrangedSubviews removeObject:view];
     [view removeFromSuperview];
   } else {
     NSArray *constraint = [self constraintsAffectingView:view];


### PR DESCRIPTION
Hi!

Firstly, thanks for working on this, I just started using and it made my life a lot simpler! :smiley_cat: 
I was missing the `arrangedSubview` functionality, as also mentioned in #43, so tried to add it, including accompanying specs. 

The solution is just for `arrangedSubviews` to be mutable, initialized as either empty or with the passed in initial views and update it accordingly when inserting or removing subviews.
There is another possible enhancement, so that every place where now `self.subviews` is used, to use `self.arrangedSubviews` and completely ignore any subviews which aren't array, but I'm not sure if that's a valid option in your opinions, so I haven't implemented that here yet.

Would love to hear feedback!
Cheers! :beers: 
