### PR TITLE
Remove removeDecendentConstraints

### DIFF
--- a/Example/OAStackView/Main.storyboard
+++ b/Example/OAStackView/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E26a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="whP-gf-Uak">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="whP-gf-Uak">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -57,13 +57,13 @@
                                     </button>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="AwR-JP-fkI" firstAttribute="leading" secondItem="Ehd-QC-zJx" secondAttribute="trailing" constant="23" id="7Qi-07-WtC"/>
+                                    <constraint firstItem="AwR-JP-fkI" firstAttribute="leading" secondItem="Ehd-QC-zJx" secondAttribute="trailing" constant="23" placeholder="YES" id="7Qi-07-WtC"/>
                                     <constraint firstAttribute="width" constant="272" id="Q65-yu-Z4C"/>
-                                    <constraint firstItem="bzd-sw-5wS" firstAttribute="top" secondItem="o1j-UM-Q0C" secondAttribute="top" id="Q7H-lz-aMk"/>
-                                    <constraint firstItem="AwR-JP-fkI" firstAttribute="top" secondItem="o1j-UM-Q0C" secondAttribute="top" id="cVE-Ej-351"/>
-                                    <constraint firstItem="Ehd-QC-zJx" firstAttribute="baseline" secondItem="bzd-sw-5wS" secondAttribute="baseline" id="lXd-3O-8vq"/>
-                                    <constraint firstItem="bzd-sw-5wS" firstAttribute="leading" secondItem="o1j-UM-Q0C" secondAttribute="leading" id="vDT-pN-gs5"/>
-                                    <constraint firstItem="Ehd-QC-zJx" firstAttribute="centerX" secondItem="o1j-UM-Q0C" secondAttribute="centerX" constant="-48" id="ysS-Jj-41H"/>
+                                    <constraint firstItem="bzd-sw-5wS" firstAttribute="top" secondItem="o1j-UM-Q0C" secondAttribute="top" placeholder="YES" id="Q7H-lz-aMk"/>
+                                    <constraint firstItem="AwR-JP-fkI" firstAttribute="top" secondItem="o1j-UM-Q0C" secondAttribute="top" placeholder="YES" id="cVE-Ej-351"/>
+                                    <constraint firstItem="Ehd-QC-zJx" firstAttribute="baseline" secondItem="bzd-sw-5wS" secondAttribute="baseline" placeholder="YES" id="lXd-3O-8vq"/>
+                                    <constraint firstItem="bzd-sw-5wS" firstAttribute="leading" secondItem="o1j-UM-Q0C" secondAttribute="leading" placeholder="YES" id="vDT-pN-gs5"/>
+                                    <constraint firstItem="Ehd-QC-zJx" firstAttribute="centerX" secondItem="o1j-UM-Q0C" secondAttribute="centerX" constant="-48" placeholder="YES" id="ysS-Jj-41H"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="axisValue">
@@ -80,7 +80,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hOV-vh-kIh">
                                 <rect key="frame" x="16" y="173" width="343" height="350"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="chB-Kz-0HW">
+                                    <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="chB-Kz-0HW">
                                         <rect key="frame" x="5" y="5" width="51" height="30"/>
                                         <state key="normal" title="Vertical">
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -89,7 +89,7 @@
                                             <action selector="verticalTapped:" destination="whP-gf-Uak" eventType="touchUpInside" id="nWl-Yj-9rW"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l1L-jW-Xxv">
+                                    <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l1L-jW-Xxv">
                                         <rect key="frame" x="5" y="75" width="77" height="30"/>
                                         <state key="normal" title="Spacing (0)">
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -98,7 +98,7 @@
                                             <action selector="spacingTapped:" destination="whP-gf-Uak" eventType="touchUpInside" id="qfR-3V-V9N"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" tag="20" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xZr-vM-yFC">
+                                    <button opaque="NO" tag="20" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xZr-vM-yFC">
                                         <rect key="frame" x="5" y="103" width="86" height="30"/>
                                         <state key="normal" title="Spacing (20)">
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -107,7 +107,7 @@
                                             <action selector="spacingTapped:" destination="whP-gf-Uak" eventType="touchUpInside" id="ItS-70-x37"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" tag="30" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qYN-pG-GXW">
+                                    <button opaque="NO" tag="30" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qYN-pG-GXW">
                                         <rect key="frame" x="5" y="132" width="86" height="30"/>
                                         <state key="normal" title="Spacing (30)">
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -116,7 +116,7 @@
                                             <action selector="spacingTapped:" destination="whP-gf-Uak" eventType="touchUpInside" id="JlB-v5-rGp"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Kc-ps-wXp">
+                                    <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Kc-ps-wXp">
                                         <rect key="frame" x="5" y="30" width="70" height="30"/>
                                         <state key="normal" title="Horizontal">
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -134,7 +134,7 @@
                                             <action selector="hideAll:" destination="whP-gf-Uak" eventType="touchUpInside" id="TT2-OB-d4r"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8fo-11-Eqc">
+                                    <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8fo-11-Eqc">
                                         <rect key="frame" x="269" y="30" width="60" height="30"/>
                                         <state key="normal" title="Show All">
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -152,7 +152,7 @@
                                             <action selector="alignmentFill:" destination="whP-gf-Uak" eventType="touchUpInside" id="0e5-iz-0Ye"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jil-rV-yuH">
+                                    <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jil-rV-yuH">
                                         <rect key="frame" x="209" y="103" width="119" height="30"/>
                                         <state key="normal" title="Alignment Center">
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -161,7 +161,7 @@
                                             <action selector="alignmentCenter:" destination="whP-gf-Uak" eventType="touchUpInside" id="8pK-fN-hCa"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lY0-Y2-8qO">
+                                    <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lY0-Y2-8qO">
                                         <rect key="frame" x="203" y="132" width="122" height="30"/>
                                         <state key="normal" title="Alignment Trailing">
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -179,7 +179,7 @@
                                             <action selector="alignmentLeading:" destination="whP-gf-Uak" eventType="touchUpInside" id="szJ-9j-Qki"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zo9-bw-cL5">
+                                    <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zo9-bw-cL5">
                                         <rect key="frame" x="5" y="185" width="102" height="30"/>
                                         <state key="normal" title="Distribution Fill">
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -206,7 +206,7 @@
                                             <action selector="distributionFillProportionally:" destination="whP-gf-Uak" eventType="touchUpInside" id="Jfj-Cz-ame"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PgQ-qw-Ogl">
+                                    <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PgQ-qw-Ogl">
                                         <rect key="frame" x="5" y="265" width="182" height="30"/>
                                         <state key="normal" title="Distribution Equal Spacing">
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>

--- a/Pod/Classes/OAStackView+Constraint.h
+++ b/Pod/Classes/OAStackView+Constraint.h
@@ -17,8 +17,6 @@
 - (NSArray*)constraintsBetweenView:(UIView*)firstView andView:(UIView*)otherView
                             inAxis:(UILayoutConstraintAxis)axis includeReversed:(BOOL)includeReversed;
 
-- (void)removeDecendentConstraints;
-
 - (NSArray*)firstConstraintAffectingView:(UIView*)superView andView:(UIView*)childView inAxis:(UILayoutConstraintAxis)axis;
 - (NSArray*)lastConstraintAffectingView:(UIView*)superView andView:(UIView*)childView inAxis:(UILayoutConstraintAxis)axis;
 

--- a/Pod/Classes/OAStackView+Constraint.m
+++ b/Pod/Classes/OAStackView+Constraint.m
@@ -121,16 +121,6 @@
   return arr;
 }
 
-- (void)removeDecendentConstraints {
-  for (NSInteger i = self.constraints.count - 1; i >= 0 ; i--) {
-    NSLayoutConstraint *constraint = self.constraints[i];
-    if ([self.subviews containsObject:constraint.firstItem] ||
-        [self.subviews containsObject:constraint.secondItem]) {
-      [self removeConstraint:constraint];
-    }
-  }
-}
-
 - (BOOL)isConstraint:(NSLayoutConstraint*)constraint affectingAxis:(UILayoutConstraintAxis)axis {
   return [self isConstraintAttribute:constraint.firstAttribute affectingAxis:axis] ||
   [self isConstraintAttribute:constraint.secondAttribute affectingAxis:axis];

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -63,8 +63,8 @@
   _layoutMargins = UIEdgeInsetsMake(0, 8, 0, 8);
   _layoutMarginsRelativeArrangement = NO;
 
-  _alignmentStrategy = [OAStackViewAlignmentStrategy strategyWithStackView:self];
-  _distributionStrategy = [OAStackViewDistributionStrategy strategyWithStackView:self];
+  self.alignmentStrategy = [OAStackViewAlignmentStrategy strategyWithStackView:self];
+  self.distributionStrategy = [OAStackViewDistributionStrategy strategyWithStackView:self];
   
   [self layoutArrangedViews];
 }
@@ -110,7 +110,7 @@
   if (_axis == axis) { return; }
   
   _axis = axis;
-  _alignmentStrategy = [OAStackViewAlignmentStrategy strategyWithStackView:self];
+  self.alignmentStrategy = [OAStackViewAlignmentStrategy strategyWithStackView:self];
   
   [self layoutArrangedViews];
 }
@@ -139,6 +139,16 @@
   }];
   
   [self.alignmentStrategy alignLastView:self.subviews.lastObject];
+}
+
+- (void)setAlignmentStrategy:(OAStackViewAlignmentStrategy *)alignmentStrategy {
+  [_alignmentStrategy removeAddedConstraints];
+  _alignmentStrategy = alignmentStrategy;
+}
+
+- (void)setDistributionStrategy:(OAStackViewDistributionStrategy *)distributionStrategy {
+  [_distributionStrategy removeAddedConstraints];
+  _distributionStrategy = distributionStrategy;
 }
 
 - (void)removeConstraint:(NSLayoutConstraint *)constraint {
@@ -318,7 +328,8 @@
 #pragma mark - Align View
 
 - (void)layoutArrangedViews {
-  [self removeDecendentConstraints];
+  [self.distributionStrategy removeAddedConstraints];
+  [self.alignmentStrategy removeAddedConstraints];
 
   [self setAlignmentConstraints];
   [self setDistributionConstraints];

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -108,10 +108,7 @@
 
 - (void)setAxis:(UILayoutConstraintAxis)axis {
   if (_axis == axis) { return; }
-  
   _axis = axis;
-  self.alignmentStrategy = [OAStackViewAlignmentStrategy strategyWithStackView:self];
-  
   [self layoutArrangedViews];
 }
 
@@ -128,7 +125,6 @@
 }
 
 - (void)setAlignmentConstraints {
-  [self.alignmentStrategy removeAddedConstraints];
   self.alignmentStrategy = [OAStackViewAlignmentStrategy strategyWithStackView:self];
   
   [self.alignmentStrategy alignFirstView:self.subviews.firstObject];
@@ -184,13 +180,10 @@
   if (_distribution == distribution) { return; }
   
   _distribution = distribution;
-  [self setAlignmentConstraints];
-  [self setDistributionConstraints];
+  [self layoutArrangedViews];
 }
 
 - (void)setDistributionConstraints {
-  [self.distributionStrategy removeAddedConstraints];
-  
   self.distributionStrategy = [OAStackViewDistributionStrategy strategyWithStackView:self];
   
   [self iterateVisibleViews:^(UIView *view, UIView *previousView) {
@@ -336,9 +329,11 @@
 #pragma mark - Align View
 
 - (void)layoutArrangedViews {
-  [self.distributionStrategy removeAddedConstraints];
-  [self.alignmentStrategy removeAddedConstraints];
-
+  NSMutableArray *constraints = [NSMutableArray array];
+  [constraints addObjectsFromArray:self.alignmentStrategy.addedConstraints];
+  [constraints addObjectsFromArray:self.distributionStrategy.addedConstraints];
+  [self removeConstraints:constraints];
+  
   [self setAlignmentConstraints];
   [self setDistributionConstraints];
 }

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -142,11 +142,19 @@
 }
 
 - (void)setAlignmentStrategy:(OAStackViewAlignmentStrategy *)alignmentStrategy {
+  if ([_alignmentStrategy isEqual:alignmentStrategy]) {
+    return;
+  }
+  
   [_alignmentStrategy removeAddedConstraints];
   _alignmentStrategy = alignmentStrategy;
 }
 
 - (void)setDistributionStrategy:(OAStackViewDistributionStrategy *)distributionStrategy {
+  if ([_distributionStrategy isEqual:distributionStrategy]) {
+    return;
+  }
+  
   [_distributionStrategy removeAddedConstraints];
   _distributionStrategy = distributionStrategy;
 }

--- a/Pod/Classes/OAStackViewAlignmentStrategy.h
+++ b/Pod/Classes/OAStackViewAlignmentStrategy.h
@@ -12,6 +12,8 @@
 
 @interface OAStackViewAlignmentStrategy : NSObject
 
+@property(nonatomic, readonly) NSArray *addedConstraints;
+
 + (OAStackViewAlignmentStrategy*)strategyWithStackView:(OAStackView *)stackView;
 
 - (void)addConstraintsOnOtherAxis:(UIView*)view;

--- a/Pod/Classes/OAStackViewAlignmentStrategy.m
+++ b/Pod/Classes/OAStackViewAlignmentStrategy.m
@@ -112,8 +112,8 @@
   if (arr) { [self.stackView addConstraints:arr]; }
 }
 
-- (NSMutableArray *)addedConstraints {
-  return self.constraints;
+- (NSArray *)addedConstraints {
+  return [self.constraints copy];
 }
 
 - (void)removeAddedConstraints {

--- a/Pod/Classes/OAStackViewAlignmentStrategy.m
+++ b/Pod/Classes/OAStackViewAlignmentStrategy.m
@@ -98,14 +98,14 @@
 }
 
 - (void)addConstraintsOnOtherAxis:(UIView*)view {
-  id arr = [self constraintsalignViewOnOtherAxis:view];
+  NSArray *arr = [self constraintsalignViewOnOtherAxis:view];
   [self.constraints addObjectsFromArray:arr];
   
   if (arr) { [self.stackView addConstraints:arr]; }
 }
 
 - (void)alignView:(UIView*)view withPreviousView:(UIView*)previousView {
-  id arr = [self constraintsAlignView:view afterPreviousView:previousView];
+  NSArray *arr = [self constraintsAlignView:view afterPreviousView:previousView];
   [self.constraints addObjectsFromArray:arr];
   
   if (arr) { [self.stackView addConstraints:arr]; }
@@ -147,7 +147,7 @@
 
 - (void)alignFirstView:(UIView*)view {
   if(!view) { return; }
-  id arr = [self firstViewConstraints:view withParentView:self.stackView];
+  NSArray *arr = [self firstViewConstraints:view withParentView:self.stackView];
   if(!arr) { return; }
   
   [self.constraints addObjectsFromArray:arr];
@@ -156,7 +156,7 @@
 
 - (void)alignLastView:(UIView*)view {
   if(!view) { return; }
-  id arr = [self lastViewConstraints:view withParentView:self.stackView];
+  NSArray *arr = [self lastViewConstraints:view withParentView:self.stackView];
   if(!arr) { return; }
   
   [self.constraints addObjectsFromArray:arr];

--- a/Pod/Classes/OAStackViewAlignmentStrategy.m
+++ b/Pod/Classes/OAStackViewAlignmentStrategy.m
@@ -68,7 +68,8 @@
 - (instancetype)initWithWithStackView:(OAStackView *)stackView {
   self = [super init];
   if (self) {
-    _stackView = stackView;;
+    _stackView = stackView;
+    _constraints = [NSMutableArray array];
   }
   return self;
 }
@@ -111,12 +112,8 @@
   if (arr) { [self.stackView addConstraints:arr]; }
 }
 
-- (NSMutableArray *)constraints {
-  if (!_constraints) {
-    _constraints = [@[] mutableCopy];
-  }
-  
-  return _constraints;
+- (NSMutableArray *)addedConstraints {
+  return self.constraints;
 }
 
 - (void)removeAddedConstraints {
@@ -151,7 +148,7 @@
   if(!arr) { return; }
   
   [self.constraints addObjectsFromArray:arr];
-  if (arr) { [self.stackView addConstraints:arr]; }
+  [self.stackView addConstraints:arr];
 }
 
 - (void)alignLastView:(UIView*)view {
@@ -160,7 +157,7 @@
   if(!arr) { return; }
   
   [self.constraints addObjectsFromArray:arr];
-  if (arr) { [self.stackView addConstraints:arr]; }
+  [self.stackView addConstraints:arr];
 }
 
 - (NSArray*)firstViewConstraints:(UIView*)view withParentView:(UIView*)parentView {

--- a/Pod/Classes/OAStackViewAlignmentStrategyBaseline.m
+++ b/Pod/Classes/OAStackViewAlignmentStrategyBaseline.m
@@ -12,7 +12,7 @@
 @implementation OAStackViewAlignmentStrategyBaseline
 
 - (NSArray*)constraintsalignViewOnOtherAxis:(UIView*)view {
-  id constraintString = [NSString stringWithFormat:@"%@:|-(>=0@750)-[view]-(>=0@750)-|", [self otherAxisString]];
+  NSString *constraintString = [NSString stringWithFormat:@"%@:|-(>=0@750)-[view]-(>=0@750)-|", [self otherAxisString]];
   
   return [NSLayoutConstraint constraintsWithVisualFormat:constraintString
                                                  options:0

--- a/Pod/Classes/OAStackViewDistributionStrategy.h
+++ b/Pod/Classes/OAStackViewDistributionStrategy.h
@@ -12,6 +12,8 @@
 
 @interface OAStackViewDistributionStrategy : NSObject
 
+@property(nonatomic, readonly) NSArray *addedConstraints;
+
 + (OAStackViewDistributionStrategy*)strategyWithStackView:(OAStackView *)stackView;
 
 - (void)alignView:(UIView*)view afterView:(UIView*)previousView;

--- a/Pod/Classes/OAStackViewDistributionStrategy.m
+++ b/Pod/Classes/OAStackViewDistributionStrategy.m
@@ -67,6 +67,7 @@
   self = [super init];
   if (self) {
     _stackView = stackView;
+    _constraints = [NSMutableArray array];
   }
   return self;
 }
@@ -152,12 +153,8 @@
     }
 }
 
-- (NSMutableArray *)constraints {
-  if (!_constraints) {
-    _constraints = [@[] mutableCopy];
-  }
-  
-  return _constraints;
+- (NSArray *)addedConstraints {
+  return self.constraints;
 }
 
 - (void)removeAddedConstraints {
@@ -187,7 +184,7 @@
     return;
   }
   
-  id constraint = [NSLayoutConstraint constraintWithItem:view
+  NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:view
                                                attribute:[self equalityAxis]
                                                relatedBy:NSLayoutRelationEqual
                                                   toItem:otherView
@@ -220,7 +217,7 @@
     multiplier = view.intrinsicContentSize.height / otherView.intrinsicContentSize.height;
   }
 
-  id constraint = [NSLayoutConstraint constraintWithItem:view
+  NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:view
                                                attribute:[self equalityAxis]
                                                relatedBy:NSLayoutRelationEqual
                                                   toItem:otherView
@@ -326,8 +323,7 @@
 
 - (void)removeAddedConstraints
 {
-  [self.stackView removeConstraints:self.constraints];
-  [self.constraints removeAllObjects];
+  [super removeAddedConstraints];
 
   [self.equalSpacingLayoutGuides makeObjectsPerformSelector:@selector(removeFromSuperview)];
   [self.equalSpacingLayoutGuides removeAllObjects];

--- a/Pod/Classes/OAStackViewDistributionStrategy.m
+++ b/Pod/Classes/OAStackViewDistributionStrategy.m
@@ -90,21 +90,25 @@
 - (void)alignLastView:(UIView*)view {
   NSString *constraintString = [NSString stringWithFormat:@"%@:[view]-(lastMargin)-|", [self currentAxisString]];
   NSNumber *lastMargin = @([self lastMargin]);
-  [self.stackView addConstraints:
-   [NSLayoutConstraint constraintsWithVisualFormat:constraintString
-                                           options:0
-                                           metrics:NSDictionaryOfVariableBindings(lastMargin)
-                                             views:NSDictionaryOfVariableBindings(view)]];
+  id arr = [NSLayoutConstraint constraintsWithVisualFormat:constraintString
+                                                   options:0
+                                                   metrics:NSDictionaryOfVariableBindings(lastMargin)
+                                                     views:NSDictionaryOfVariableBindings(view)];
+    
+  [self.constraints addObjectsFromArray:arr];
+  [self.stackView addConstraints:arr];
 }
 
 - (void)alignFirstView:(UIView*)view {
   NSString *str = [NSString stringWithFormat:@"%@:|-(firstMargin)-[view]", [self currentAxisString]];
   NSNumber *firstMargin = @([self firstMargin]);
-  [self.stackView addConstraints:
-   [NSLayoutConstraint constraintsWithVisualFormat:str
-                                           options:0
-                                           metrics:NSDictionaryOfVariableBindings(firstMargin)
-                                             views:NSDictionaryOfVariableBindings(view)]];
+  id arr = [NSLayoutConstraint constraintsWithVisualFormat:str
+                                                   options:0
+                                                   metrics:NSDictionaryOfVariableBindings(firstMargin)
+                                                     views:NSDictionaryOfVariableBindings(view)];
+    
+  [self.constraints addObjectsFromArray:arr];
+  [self.stackView addConstraints:arr];
 }
 
 

--- a/Pod/Classes/OAStackViewDistributionStrategy.m
+++ b/Pod/Classes/OAStackViewDistributionStrategy.m
@@ -90,7 +90,7 @@
 - (void)alignLastView:(UIView*)view {
   NSString *constraintString = [NSString stringWithFormat:@"%@:[view]-(lastMargin)-|", [self currentAxisString]];
   NSNumber *lastMargin = @([self lastMargin]);
-  id arr = [NSLayoutConstraint constraintsWithVisualFormat:constraintString
+  NSArray *arr = [NSLayoutConstraint constraintsWithVisualFormat:constraintString
                                                    options:0
                                                    metrics:NSDictionaryOfVariableBindings(lastMargin)
                                                      views:NSDictionaryOfVariableBindings(view)];
@@ -102,7 +102,7 @@
 - (void)alignFirstView:(UIView*)view {
   NSString *str = [NSString stringWithFormat:@"%@:|-(firstMargin)-[view]", [self currentAxisString]];
   NSNumber *firstMargin = @([self firstMargin]);
-  id arr = [NSLayoutConstraint constraintsWithVisualFormat:str
+  NSArray *arr = [NSLayoutConstraint constraintsWithVisualFormat:str
                                                    options:0
                                                    metrics:NSDictionaryOfVariableBindings(firstMargin)
                                                      views:NSDictionaryOfVariableBindings(view)];
@@ -118,7 +118,7 @@
                    [self symbolicSpacingRelation],
                    self.stackView.spacing];
   
-  id arr = [NSLayoutConstraint constraintsWithVisualFormat:str
+  NSArray *arr = [NSLayoutConstraint constraintsWithVisualFormat:str
                                                    options:0
                                                    metrics:nil
                                                      views:NSDictionaryOfVariableBindings(view, previousView)];

--- a/Pod/Classes/OAStackViewDistributionStrategy.m
+++ b/Pod/Classes/OAStackViewDistributionStrategy.m
@@ -154,7 +154,7 @@
 }
 
 - (NSArray *)addedConstraints {
-  return self.constraints;
+  return [self.constraints copy];
 }
 
 - (void)removeAddedConstraints {


### PR DESCRIPTION
This PR removes `removeDecendentConstraints` method, since the method basically removed all constraints that involved its subviews (and not only constraints added by the OAStackView layout).

Changes:
- OAStackView will use the property for alignmentStrategy and distributionStrategy rather than the synthesized instance variable
- Implemented setAlignmentStrategy and setDistributionStrategy that removes the previous strategies constraints on OAStackView
- OAStackViewDistributionStategy now adds the constraints created by alignLastView: and alignFirstView: to its array of constraints
- Removed the removeDecendentConstraints method.
- OAStackView will only remove the strategies constraints during layoutArrangedViews
