### PR TITLE
Do not add subviews twice and thus not subscribe to KVO twice

### DIFF
--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -39,7 +39,6 @@
     [self commonInitWithInitalSubviews:@[]];
 
     if ([NSStringFromClass([self class]) isEqualToString:@"UIStackView"]) {
-      [self addViewsAsSubviews:[decoder decodeObjectForKey:@"UIStackViewArrangedSubviews"]];
       self.axis = [decoder decodeIntegerForKey:@"UIStackViewAxis"];
       self.distribution = [decoder decodeIntegerForKey:@"UIStackViewDistribution"];
       self.alignment = [decoder decodeIntegerForKey:@"UIStackViewAlignment"];


### PR DESCRIPTION
Setup for crashing is following (minimal one I've experienced in my app):
- iOS8
- One `stackView` inside another used from inside xib.

Apparently `- (instancetype)initWithCoder:(NSCoder *)decoder` returns view with subviews added. Even though `addSubview:` was clever enough to not add subview to stackView twice (removed line), it still had consequences: observers to `hidden` property (`OAStackView+Hiding.h`) where added twice which caused crash on master view deallocation.
