### PR TITLE
Fix bug where OAStackView.axis didn't actually default to vertical.

### DIFF
--- a/Example/Tests/OAStackViewSpec.m
+++ b/Example/Tests/OAStackViewSpec.m
@@ -1018,6 +1018,10 @@ describe(@"OAStackView", ^{
       [[theValue(CGRectGetWidth(stackView.frame)) should] equal:theValue(50)];
     });
     
+    it(@"should default to vertical axis", ^{
+        OAStackView *stackView = [[OAStackView alloc] init];
+        [[theValue(stackView.axis) should] equal:theValue(UILayoutConstraintAxisVertical)];
+    });
   });
 });
 

--- a/Pod/Classes/OAStackView.m
+++ b/Pod/Classes/OAStackView.m
@@ -72,7 +72,7 @@
   _mutableArrangedSubviews = [initialSubviews mutableCopy];
   [self addViewsAsSubviews:initialSubviews];
 
-  _axis = UILayoutConstraintAxisHorizontal;
+  _axis = UILayoutConstraintAxisVertical;
   _alignment = OAStackViewAlignmentFill;
   _distribution = OAStackViewDistributionFill;
 


### PR DESCRIPTION
`OAStackView.axis` has a comment saying `//Default is Vertical`, but the default was actually horizontal. This pullreq adds a test for the default axis, and makes it actually default to vertical.
