### PR TITLE
Reverted back to simple imports so swift interoperability works better

### DIFF
--- a/Pod/Classes/OAStackView+Constraint.h
+++ b/Pod/Classes/OAStackView+Constraint.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import <OAStackView/OAStackView.h>
+#import "OAStackView.h"
 
 @interface OAStackView (Constraint)
 

--- a/Pod/Classes/OAStackView+Hiding.h
+++ b/Pod/Classes/OAStackView+Hiding.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import <OAStackView/OAStackView.h>
+#import "OAStackView.h"
 
 @interface OAStackView (Hiding)
 

--- a/Pod/Classes/OAStackView+Traversal.h
+++ b/Pod/Classes/OAStackView+Traversal.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import <OAStackView/OAStackView.h>
+#import "OAStackView.h"
 
 @interface OAStackView (Traversal)
 


### PR DESCRIPTION
If OAStackView is used as a dependency in another pod then after installation OAStackView causes "Include of non-modular header inside framework" compile error.
For fixing this problem - following the general solution by other open source libraries - I reverted back to simple imports inside the project.
