### PR TITLE
OAStackViewProxy

### DIFF
--- a/Example/OAStackView.xcodeproj/project.pbxproj
+++ b/Example/OAStackView.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		A7CC22B31B2E0B8E009C9911 /* OAStackViewSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = A7CC22B11B2E0B46009C9911 /* OAStackViewSpec.m */; };
 		A7CC22B51B2E0BC7009C9911 /* Launch Screen.xib in Resources */ = {isa = PBXBuildFile; fileRef = A7CC22B41B2E0BC7009C9911 /* Launch Screen.xib */; };
-		D21E827A1BCF97D400D8379B /* OAUIStackViewViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D21E82791BCF97D400D8379B /* OAUIStackViewViewController.m */; settings = {ASSET_TAGS = (); }; };
+		D21E827A1BCF97D400D8379B /* OAUIStackViewViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D21E82791BCF97D400D8379B /* OAUIStackViewViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */

--- a/Example/OAStackView.xcodeproj/project.pbxproj
+++ b/Example/OAStackView.xcodeproj/project.pbxproj
@@ -531,6 +531,7 @@
 			baseConfigurationReference = 4A479030BF663DB64E709BCD /* Pods-OAStackView_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "OAStackView/OAStackView-Prefix.pch";
 				INFOPLIST_FILE = "OAStackView/OAStackView-Info.plist";
@@ -545,6 +546,7 @@
 			baseConfigurationReference = 6CB38A1284EC102F864DB60A /* Pods-OAStackView_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "OAStackView/OAStackView-Prefix.pch";
 				INFOPLIST_FILE = "OAStackView/OAStackView-Info.plist";

--- a/Example/OAStackView.xcodeproj/xcshareddata/xcschemes/OAStackView-Example.xcscheme
+++ b/Example/OAStackView.xcodeproj/xcshareddata/xcschemes/OAStackView-Example.xcscheme
@@ -48,6 +48,8 @@
             ReferencedContainer = "container:OAStackView.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -57,6 +59,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Example/OAStackView/OAStackViewViewController.m
+++ b/Example/OAStackView/OAStackViewViewController.m
@@ -7,10 +7,11 @@
 //
 
 #import "OAStackViewViewController.h"
-#import "OAStackView.h"
+#import <OAStackView/OAStackView-Swift.h>
+#import <OAStackView/OAStackView.h>
 
 @interface OAStackViewViewController ()
-@property (weak, nonatomic) IBOutlet OAStackView *stackView;
+@property (weak, nonatomic) OAStackViewProxy *stackView;
 @property (weak, nonatomic) IBOutlet UIView *viewToRemove;
 @end
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Kiwi (2.4.0)
-  - OAStackView (0.2.0)
+  - OAStackView (1.0.1)
   - Reveal-iOS-SDK (1.5.1)
 
 DEPENDENCIES:
@@ -10,11 +10,11 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   OAStackView:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   Kiwi: f49c9d54b28917df5928fe44968a39ed198cb8a8
-  OAStackView: a05adfec3669a5187b968a8c0a2690ae517271b6
+  OAStackView: 95e7cb79cbea25c2342f496a44bdbe8bd4c8d510
   Reveal-iOS-SDK: c9c55cad2729c85f6ced415f1b21857c9a2d8ef9
 
 COCOAPODS: 0.39.0

--- a/OAStackView.xcodeproj/project.pbxproj
+++ b/OAStackView.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		8298C91A1B4188700006C53E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0630;
 				ORGANIZATIONNAME = OAStackView;
 				TargetAttributes = {
@@ -296,16 +297,20 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -314,16 +319,19 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/OAStackView.xcodeproj/project.pbxproj
+++ b/OAStackView.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		3B1224651B4DF25200C02D3A /* OAStackViewDistributionStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B1224571B4DF25200C02D3A /* OAStackViewDistributionStrategy.m */; };
 		80BE14951B79041F00809203 /* OAStackViewAlignmentStrategyBaseline.h in Headers */ = {isa = PBXBuildFile; fileRef = 80BE14931B79041F00809203 /* OAStackViewAlignmentStrategyBaseline.h */; };
 		80BE14961B79041F00809203 /* OAStackViewAlignmentStrategyBaseline.m in Sources */ = {isa = PBXBuildFile; fileRef = 80BE14941B79041F00809203 /* OAStackViewAlignmentStrategyBaseline.m */; };
+		8416A2DB1CDA836F00D6C25B /* OAStackViewProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8416A2DA1CDA836F00D6C25B /* OAStackViewProxy.swift */; };
 		D871CEF71B685D8500FD5F11 /* OATransformLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = D871CEF51B685D8500FD5F11 /* OATransformLayer.h */; };
 		D871CEF81B685D8500FD5F11 /* OATransformLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = D871CEF61B685D8500FD5F11 /* OATransformLayer.m */; };
 /* End PBXBuildFile section */
@@ -46,6 +47,7 @@
 		80BE14941B79041F00809203 /* OAStackViewAlignmentStrategyBaseline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OAStackViewAlignmentStrategyBaseline.m; path = Pod/Classes/OAStackViewAlignmentStrategyBaseline.m; sourceTree = SOURCE_ROOT; };
 		8298C9231B4188700006C53E /* OAStackView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OAStackView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8298C93F1B4188F50006C53E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
+		8416A2DA1CDA836F00D6C25B /* OAStackViewProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OAStackViewProxy.swift; path = Pod/Classes/OAStackViewProxy.swift; sourceTree = SOURCE_ROOT; };
 		D871CEF51B685D8500FD5F11 /* OATransformLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OATransformLayer.h; path = Pod/Classes/OATransformLayer.h; sourceTree = SOURCE_ROOT; };
 		D871CEF61B685D8500FD5F11 /* OATransformLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OATransformLayer.m; path = Pod/Classes/OATransformLayer.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
@@ -99,6 +101,7 @@
 				D871CEF51B685D8500FD5F11 /* OATransformLayer.h */,
 				D871CEF61B685D8500FD5F11 /* OATransformLayer.m */,
 				8298C93F1B4188F50006C53E /* Info.plist */,
+				8416A2DA1CDA836F00D6C25B /* OAStackViewProxy.swift */,
 			);
 			path = OAStackView;
 			sourceTree = "<group>";
@@ -199,6 +202,7 @@
 				3B12245F1B4DF25200C02D3A /* OAStackView+Hiding.m in Sources */,
 				D871CEF81B685D8500FD5F11 /* OATransformLayer.m in Sources */,
 				3B12245D1B4DF25200C02D3A /* OAStackView+Constraint.m in Sources */,
+				8416A2DB1CDA836F00D6C25B /* OAStackViewProxy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OAStackView.xcodeproj/xcshareddata/xcschemes/OAStackView.xcscheme
+++ b/OAStackView.xcodeproj/xcshareddata/xcschemes/OAStackView.xcscheme
@@ -62,6 +62,8 @@
             ReferencedContainer = "container:OAStackView.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -71,6 +73,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Pod/Classes/OAStackViewProxy.swift
+++ b/Pod/Classes/OAStackViewProxy.swift
@@ -1,0 +1,183 @@
+//
+//  OAStackViewProxy.swift
+//  Masilotti.com
+//
+//  Created by Joe Masilotti on 5/4/16.
+//  Copyright © 2016 Masilotti.com. All rights reserved.
+//
+
+import UIKit
+
+@objc public class OAStackViewProxy: UIView {
+    public init() {
+        super.init(frame: CGRectZero)
+        if #available(iOS 9, *) {
+            installFullScreenView(nativeStackView)
+        } else {
+            installFullScreenView(backwardsCompatibleStackView)
+        }
+    }
+
+    public init(arrangedSubviews: [UIView]) {
+        super.init(frame: CGRectZero)
+        if #available(iOS 9, *) {
+            installFullScreenView(nativeStackView)
+            arrangedSubviews.forEach({ (view) in nativeStackView.addArrangedSubview(view) })
+        } else {
+            installFullScreenView(backwardsCompatibleStackView)
+            arrangedSubviews.forEach({ (view) in backwardsCompatibleStackView.addArrangedSubview(view) })
+        }
+    }
+
+    public required init?(coder aDecoder: NSCoder) { fatalError("Unimplemented.") }
+
+    override public var subviews: [UIView] {
+        if #available(iOS 9, *) {
+            return nativeStackView.subviews
+        } else {
+            return backwardsCompatibleStackView.subviews
+        }
+    }
+
+    public var arrangedSubviews: [UIView] {
+        if #available(iOS 9, *) {
+            return nativeStackView.arrangedSubviews
+        } else {
+            return backwardsCompatibleStackView.arrangedSubviews
+        }
+    }
+
+    public func addArrangedSubview(view: UIView) {
+        if #available(iOS 9, *) {
+            nativeStackView.addArrangedSubview(view)
+        } else {
+            backwardsCompatibleStackView.addArrangedSubview(view)
+        }
+    }
+
+    public func removeArrangedSubview(view: UIView) {
+        if #available(iOS 9, *) {
+            nativeStackView.removeArrangedSubview(view)
+        } else {
+            backwardsCompatibleStackView.removeArrangedSubview(view)
+        }
+    }
+
+    public var axis: UILayoutConstraintAxis = .Horizontal {
+        didSet {
+            if #available(iOS 9, *) {
+                nativeStackView.axis = axis
+            } else {
+                backwardsCompatibleStackView.axis = axis
+            }
+        }
+    }
+
+    public var distribution: OAStackViewDistribution = .Fill {
+        didSet {
+            if #available(iOS 9, *) {
+                nativeStackView.distribution = UIStackViewDistribution(distribution: distribution)
+            } else {
+                backwardsCompatibleStackView.distribution = distribution
+            }
+        }
+    }
+
+    public var alignment: OAStackViewAlignment = .Fill {
+        didSet {
+            if #available(iOS 9, *) {
+                nativeStackView.alignment = UIStackViewAlignment(alignment: alignment)
+            } else {
+                backwardsCompatibleStackView.alignment = alignment
+            }
+        }
+    }
+
+    public var spacing: CGFloat = 0.0 {
+        didSet {
+            if #available(iOS 9, *) {
+                nativeStackView.spacing = spacing
+            } else {
+                backwardsCompatibleStackView.spacing = spacing
+            }
+        }
+    }
+
+    public var baselineRelativeArrangement: Bool = false {
+        didSet {
+            if #available(iOS 9, *) {
+                nativeStackView.baselineRelativeArrangement = baselineRelativeArrangement
+            }
+        }
+    }
+
+    public var layoutMarginsRelativeArrangement: Bool = false {
+        didSet {
+            if #available(iOS 9, *) {
+                nativeStackView.layoutMarginsRelativeArrangement = layoutMarginsRelativeArrangement
+            }
+        }
+    }
+
+    @available(iOS 9.0, *)
+    private lazy var nativeStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    private lazy var backwardsCompatibleStackView: OAStackView = {
+        let stackView = OAStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+}
+
+@available(iOS 9, *)
+private extension UIStackViewAlignment {
+    init(alignment: OAStackViewAlignment) {
+        switch alignment {
+        case .Fill:
+            self = .Fill
+        case .Leading:
+            self = .Leading
+        case .FirstBaseline:
+            self = .FirstBaseline
+        case .Center:
+            self = .Center
+        case .Trailing:
+            self = .Trailing
+        case .Baseline:
+            self = .FirstBaseline
+        }
+    }
+}
+
+@available(iOS 9, *)
+private extension UIStackViewDistribution {
+    init(distribution: OAStackViewDistribution) {
+        switch distribution {
+        case .Fill:
+            self = .Fill
+        case .FillEqually:
+            self = .FillEqually
+        case .FillProportionally:
+            self = .FillProportionally
+        case .EqualSpacing:
+            self = .EqualSpacing
+        case .EqualCentering:
+            self = .EqualCentering
+        }
+    }
+}
+
+private extension UIView {
+    func installFullScreenView(view: UIView) {
+        addSubview(view)
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        let views = ["view": view]
+        addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options: [], metrics: nil, views: views))
+        addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options: [], metrics: nil, views: views))
+    }
+}


### PR DESCRIPTION
This PR enables developers to use a single API when dealing with stack views. `OAStackViewProxy` wraps a `UIStackView` on iOS 9 and an `OAStackVew` on any older OS version. 

Each method call takes advantage of Swift's build in `#avaiable` API to determine which stack view to use under the hood. Each property is exposed on the proxy with `OAStackView`'s enum types. The proxy also takes advantage of Swift's `didSet` to update properties on the stack views.

I updated the example app to use the proxy over an `OAStackView` directly. This means we don't have to modify the tests because we are already using the class. However, this is only the case on iOS 8. Running the tests on iOS 9 will just use a wrapped `UIStackView`.

One caveat to this approach is that the target application needs to import `<OAStackView/OAStackView-Swift.h>` to use the proxy. I also had to enable `CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES` to successfully build the module. Perhaps someone with more experience in building frameworks can lend a hand here.

**Note**: Storyboards are not supported.

This PR was inspired by @natanrolnik's work on #32.
