### PR TITLE
Remove subviews override for proxy

### DIFF
--- a/Pod/Classes/OAStackViewProxy.swift
+++ b/Pod/Classes/OAStackViewProxy.swift
@@ -31,14 +31,6 @@ import UIKit
 
     public required init?(coder aDecoder: NSCoder) { fatalError("Unimplemented.") }
 
-    override public var subviews: [UIView] {
-        if #available(iOS 9, *) {
-            return nativeStackView.subviews
-        } else {
-            return backwardsCompatibleStackView.subviews
-        }
-    }
-
     public var arrangedSubviews: [UIView] {
         if #available(iOS 9, *) {
             return nativeStackView.arrangedSubviews


### PR DESCRIPTION
This can cause issues when you embed the proxy with auto layout. Direct access to the actual subviews can be achieved via `arrangedSubviews`.
