### PR TITLE
remove resource bundle definition from podspec

### DIFF
--- a/OAStackView.podspec
+++ b/OAStackView.podspec
@@ -16,8 +16,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes/**/*'
-  s.resource_bundles = {
-    'OAStackView' => ['Pod/Assets/*.png']
-  }
 
 end


### PR DESCRIPTION
I'm recently examine all private podspec definitions I use in my project, and I found `OAStackView` has an empty resource bundle sitting inside `my_proj.app` package like this:

![1](https://cloud.githubusercontent.com/assets/5897680/19218603/c1afdc7e-8e30-11e6-9c83-568d60b28908.png)

It's not a big deal, but since I came across this... there you go, I propose deleting the unnecessary resource bundle definition.
